### PR TITLE
Info to onboard older modules

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -5,6 +5,7 @@
     - [Local development setup](local-dev-setup.md)
     - [Regular developer tasks](dev-maintenance.md)
     - [Contributing a module](contribute-module.md)
+    - [Update an older module ](migrate-module.md)
     - [Validation tests](tests.md)
     - [GitHub Actions workflows](gh-actions.md)
     - Creating docs for your module (coming)

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -5,7 +5,7 @@
     - [Local development setup](local-dev-setup.md)
     - [Regular developer tasks](dev-maintenance.md)
     - [Contributing a module](contribute-module.md)
-    - [Update an older module ](migrate-module.md)
+    - [Updating an older module ](migrate-module.md)
     - [Validation tests](tests.md)
     - [GitHub Actions workflows](gh-actions.md)
     - Creating docs for your module (coming)

--- a/docs/contribute-module.md
+++ b/docs/contribute-module.md
@@ -12,19 +12,19 @@ Follow these steps to create or update a module.
 
 ## Before you begin
 
-- Submit an issue in the [terraform-ibm-issue-tracker](https://github.com/terraform-ibm-modules/terraform-ibm-issue-tracker/issues/new/choose) with your idea for a module.
 - If you're running Microsoft Windows, set up Windows Subsystem for Linux [WSL](https://ubuntu.com/wsl) and run commands within WSL.
 - Make sure that you have a current version of Python 3 and pip.
 - Make sure that you have a recent stable version of [Go](https://go.dev/doc/install) installed and available in your PATH environment variable.
 
-## Create a module
+## Request a repo
 
-If you're updating an existing module, skip to the next step. Otherwise, create a module repo from the [terraform-ibm-module-template](https://github.com/terraform-ibm-modules/terraform-ibm-module-template).
+?> **Tip:** If you're updating an existing module, skip to the next step.
 
-1.  Create a repository from the [terraform-ibm-module-template](https://github.com/terraform-ibm-modules/terraform-ibm-module-template) repo by clicking `Use this template` in the upper right of the GitHub UI.
-1.  Select `terraform-ibm-modules` as the owner.
-1.  Enter a name for the module in format `terraform-ibm-<NAME>`, where `<NAME>` reflects the type of infrastructure that the module manages. Use hyphens as delimiters for names with multiple words (for example, terraform-ibm-`activity-tracker`).
-1.  Provide a short description of the module. The description is displayed under the repository title on the [organization page](https://github.com/terraform-ibm-modules) and in the **About** section of the repository. Use the description to help users understand what your repo does by looking at the description.
+Submit a request for a new module repo in the [terraform-ibm-issue-tracker](https://github.com/terraform-ibm-modules/terraform-ibm-issue-tracker/issues/new/choose) with your idea for a module.
+
+[inc-module-name-desc](inc-module-name-desc.md ':include')
+
+When your repo is created, return to this topic and continue the steps.
 
 ## Clone and initialize the repo
 

--- a/docs/dev-maintenance.md
+++ b/docs/dev-maintenance.md
@@ -24,7 +24,7 @@ git submodule update --remote --merge
 
 ## Run the pre-commit hooks manually
 
-The GoldenEye pre-commit hooks run against changed files when you commit changes to Git. To run the pre-commit hooks against all files, run the following command:
+The pre-commit hooks run against changed files when you commit changes to Git. To run the pre-commit hooks against all files, run the following command:
 
 ```bash
 pre-commit run --all-files

--- a/docs/inc-module-name-desc.md
+++ b/docs/inc-module-name-desc.md
@@ -1,0 +1,4 @@
+You'll need this information for the request:
+
+- The name for the module in the format `terraform-ibm-<NAME>`, where `<NAME>` reflects the type of infrastructure that the module manages. Use hyphens as delimiters for names with multiple words (for example, terraform-ibm-`activity-tracker`).
+- A short description of the module. The description is displayed under the repository title on the [organization page](https://github.com/terraform-ibm-modules) and in the **About** section of the repository. Use the description to help users understand what your repo does by looking at the description.

--- a/docs/migrate-module.md
+++ b/docs/migrate-module.md
@@ -109,7 +109,7 @@ Create or update at least one end-to-end example to test your code changes. You 
 
 ?> **Tip:** You can use the [migration script](https://github.com/terraform-ibm-modules/common-dev-assets/blob/main/repo_migration.sh) in the `common-dev-assets` repo to add the CI code.
 
-1.  Implement (or update) the logic for your module examples by updating the `main.tf`, `version.tf`, `variables.tf`, and `outputs.tf` Terraform files in the `examples/default` directory.
+1.  Implement (or update) the logic for your module examples by updating the `main.tf`, `outputs.tf`, `provider.tf`, `variables.tf`, and  `version.tf` Terraform files in the `examples/default` directory.
 1.  Update the `README.md` file in the same examples directory to provide some basic information about what the example does.
 
 [inc-examples](inc-examples.md ':include')

--- a/docs/migrate-module.md
+++ b/docs/migrate-module.md
@@ -1,18 +1,18 @@
 # Update an older module
 
-Module repos created before July 2022 don't include the logic that is needed to pass the continuous integration (CI) tests and to publish the modules to the IBM Cloud catalog. Follow these steps to update an existing repo in the terraform-ibm-modules GitHub organization.
+Modules in the IBM Terraform modules project need specific logic and workflows to pass the continuous integration (CI) tests and to publish the modules to the IBM Cloud catalog. To update a Terraform repo to these requirements and add it to the terraform-ibm-modules GitHub project, follow these steps.
 
 For more information about how new modules are organized, see [module structure](module-structure.md).
 
 ## Before you begin
 
-- If you're running Microsoft Windows, set up Windows Subsystem for Linux [WSL](https://ubuntu.com/wsl) and run commands within WSL.
-- Make sure that you have a current version of Python 3 and pip.
-- Make sure that you have a recent stable version of [Go](https://go.dev/doc/install) installed and available in your PATH environment variable.
+- Make sure that you meet the prerequisites in the [Before you begin](local-dev-setup.md#before-you-begin) section of "Local development setup" in the docs.
 
 ## Create an empty module
 
-Create an empty module repo in the `terraform-ibm-modules` GitHub organization.
+Create an empty module repo in the `terraform-ibm-modules` GitHub project.
+
+!> You likely do not have permissions to create a repo in the project. Submit an issue in the [terraform-ibm-issue-tracker](https://github.com/terraform-ibm-modules/terraform-ibm-issue-tracker/issues/new/choose) to request a repo.
 
 1.  In the upper right of any page in the [terraform-ibm-modules](https://github.com/terraform-ibm-modules) organization, use the **+** menu, and select **New repository**.
 1.  Select `terraform-ibm-modules` as the owner.
@@ -48,9 +48,11 @@ s
         git push origin2 main
         ```
 
-## Add the newer CI/CD code
+## Add the newer CI code
 
 Copy the following files from the `.github` directory of the terraform-ibm-module-template.
+
+?> **Tip:** You can use the [migration script](https://github.com/terraform-ibm-modules/common-dev-assets/blob/main/repo_migration.sh) in the `common-dev-assets` repo to add the CI code.
 
 1.  Browse to the [terraform-ibm-module-template](https://github.com/terraform-ibm-modules/terraform-ibm-module-template/blob/main/.github) `.github` directory.
 1.  Copy the `settings.yml` file.
@@ -58,7 +60,7 @@ Copy the following files from the `.github` directory of the terraform-ibm-modul
 
 ## Make updates to pass the pre-commit checks
 
-1.  Run the pre-commit hooks From the root of the newly cloned repo to identify other changes that you need to make:
+1.  Run the pre-commit hooks from the root of the newly cloned repo to identify other changes that you need to make:
 
     ```bash
     pre-commit run --all-files
@@ -70,6 +72,8 @@ Copy the following files from the `.github` directory of the terraform-ibm-modul
 
 Create or update at least one end-to-end example to test your code changes. You can see the structure in the [examples](https://github.com/terraform-ibm-modules/terraform-ibm-module-template/tree/main/examples) directory of the terraform-ibm-module-template.
 
+?> **Tip:** You can use the [migration script](https://github.com/terraform-ibm-modules/common-dev-assets/blob/main/repo_migration.sh) in the `common-dev-assets` repo to add the CI code.
+
 1.  Implement (or update) the logic for your module examples by updating the `main.tf`, `version.tf`, `variables.tf`, and `version.tf` Terraform files in the `examples/default` directory.
 1.  Update the `README.md` file in the same examples directory to provide some basic information about what the example does.
 
@@ -77,7 +81,7 @@ Create or update at least one end-to-end example to test your code changes. You 
 
 ## Run examples and update the PR tests
 
-Validate your Terraform logic by running the examples. Then update the test scripts to run the examples with pull requests.
+Validate your Terraform logic by running the examples. Then, update the test scripts to run the examples with pull requests.
 
 1.  Run your examples to test the logic. For more information, see [run examples and clean up](contribute-module.md#run-examples-and-clean-up) in the docs.
 

--- a/docs/migrate-module.md
+++ b/docs/migrate-module.md
@@ -2,6 +2,8 @@
 
 Module repos created before July 2022 don't include the logic that is needed to pass the continuous integration (CI) tests and to publish the modules to the IBM Cloud catalog. Follow these steps to update an existing repo in the terraform-ibm-modules GitHub organization.
 
+For more information about how new modules are organized, see [module structure](module-structure.md).
+
 ## Before you begin
 
 - If you're running Microsoft Windows, set up Windows Subsystem for Linux [WSL](https://ubuntu.com/wsl) and run commands within WSL.

--- a/docs/migrate-module.md
+++ b/docs/migrate-module.md
@@ -1,0 +1,94 @@
+# Update an older module
+
+Module repos created before July 2022 don't include the logic that is needed to pass the continuous integration (CI) tests and to publish the modules to the IBM Cloud catalog. Follow these steps to update an existing repo in the terraform-ibm-modules GitHub organization.
+
+## Before you begin
+
+- If you're running Microsoft Windows, set up Windows Subsystem for Linux [WSL](https://ubuntu.com/wsl) and run commands within WSL.
+- Make sure that you have a current version of Python 3 and pip.
+- Make sure that you have a recent stable version of [Go](https://go.dev/doc/install) installed and available in your PATH environment variable.
+
+## Create an empty module
+
+Create an empty module repo in the `terraform-ibm-modules` GitHub organization.
+
+1.  In the upper right of any page in the [terraform-ibm-modules](https://github.com/terraform-ibm-modules) organization, use the **+** menu, and select **New repository**.
+1.  Select `terraform-ibm-modules` as the owner.
+1.  Enter a name for the module in format `terraform-ibm-<NAME>`, where `<NAME>` reflects the type of infrastructure that the module manages. Use hyphens as delimiters for names with multiple words (for example, terraform-ibm-`activity-tracker`).
+1.  Provide a short description of the module. The description is displayed under the repository title on the [organization page](https://github.com/terraform-ibm-modules) and in the **About** section of the repository. Use the description to help users understand what your repo does by looking at the description.
+1.  Confirm that you are creating a public repository in the terraform-ibm-modules organization and click **Create repository**.
+
+## Clone and initialize the repo
+
+Clone the repo that you just created.
+
+[inc-clone.md](inc-clone.md ':include')
+
+## Migrate the module code
+
+1.  From the root of the newly cloned repo, create a branch to work in by running the command `git checkout -b ＜YOUR_WORKING_BRANCH>`. Replace `＜YOUR_WORKING_BRANCH>` with your own branch name.
+s
+1.  Push the module code from the older repo to the new one by running these commands:
+    1.  Add the new repo as a remote to the older repo:
+
+        ```bash
+        git remote add origin2 https://github.com/terraform-ibm-modules/<REPO_NAME>
+        ```
+
+        Where `<REPO_NAME>` is your new repo. The command uses `origin2` because Git uses `origin` by default.
+    1.  Check that the remote points from your old repo to the new one by running this command:
+
+        ```bash
+        git remote -v
+        ```
+    1.  Push the module code from the older repo to the main branch of the new repo:
+        ```bash
+        git push origin2 main
+        ```
+
+## Add the newer CI/CD code
+
+Copy the following files from the `.github` directory of the terraform-ibm-module-template.
+
+1.  Browse to the [terraform-ibm-module-template](https://github.com/terraform-ibm-modules/terraform-ibm-module-template/blob/main/.github) `.github` directory.
+1.  Copy the `settings.yml` file.
+1.  Copy the `workflows` directory that contains the GitHub Action workflow
+
+## Make updates to pass the pre-commit checks
+
+1.  Run the pre-commit hooks From the root of the newly cloned repo to identify other changes that you need to make:
+
+    ```bash
+    pre-commit run --all-files
+    ```
+
+1.  Iteratively address all the issues from this check, commit the changes, and run the `pre-commit` command until you have a clean check.
+
+## Create or update examples
+
+Create or update at least one end-to-end example to test your code changes. You can see the structure in the [examples](https://github.com/terraform-ibm-modules/terraform-ibm-module-template/tree/main/examples) directory of the terraform-ibm-module-template.
+
+1.  Implement (or update) the logic for your module examples by updating the `main.tf`, `version.tf`, `variables.tf`, and `version.tf` Terraform files in the `examples/default` directory.
+1.  Update the `README.md` file in the same examples directory to provide some basic information about what the example does.
+
+[inc-examples](inc-examples.md ':include')
+
+## Run examples and update the PR tests
+
+Validate your Terraform logic by running the examples. Then update the test scripts to run the examples with pull requests.
+
+1.  Run your examples to test the logic. For more information, see [run examples and clean up](contribute-module.md#run-examples-and-clean-up) in the docs.
+
+    After the examples run, destroy the resources.
+1.  Copy the contents of the [tests](https://github.com/terraform-ibm-modules/terraform-ibm-module-template/tree/main/tests) directory from the terraform-ibm-module-template.
+1.  Update the `pr_test.go` file to run the examples as a unit test. For more information, see [Update the PR tests](contribute-module.md#update-the-pr-tests) in the docs.
+
+## Open an initial pull request
+
+Open a pull request from your working branch in the new repo to the `main` branch.
+
+After the CI pipeline passes and the PR is merged, automation creates a GitHub semantic version release and publishes the module to the IBM Cloud catalog as a private entry initially. For more information about the CI pipeline, see [Tests](tests.md).
+
+## Next steps
+
+Archive the older repo in GitHub. Update the `readme` file to point to the new repo.

--- a/docs/migrate-module.md
+++ b/docs/migrate-module.md
@@ -1,36 +1,71 @@
-# Update an older module
+# Updating an older module
 
 Modules in the IBM Terraform modules project need specific logic and workflows to pass the continuous integration (CI) tests and to publish the modules to the IBM Cloud catalog. To update a Terraform repo to these requirements and add it to the terraform-ibm-modules GitHub project, follow these steps.
 
 For more information about how new modules are organized, see [module structure](module-structure.md).
 
+?> Tip: If you want to contribute a new module instead of migrating one, follow the steps in [Contributing a module](contribute-module.md).
+
 ## Before you begin
 
 - Make sure that you meet the prerequisites in the [Before you begin](local-dev-setup.md#before-you-begin) section of "Local development setup" in the docs.
 
-## Create an empty module
+## Request an empty module
 
-Create an empty module repo in the `terraform-ibm-modules` GitHub project.
+Submit a request in the [terraform-ibm-issue-tracker](https://github.com/terraform-ibm-modules/terraform-ibm-issue-tracker/issues/new/choose) with your idea for a module.
 
-!> You likely do not have permissions to create a repo in the project. Submit an issue in the [terraform-ibm-issue-tracker](https://github.com/terraform-ibm-modules/terraform-ibm-issue-tracker/issues/new/choose) to request a repo.
+[inc-module-name-desc](inc-module-name-desc.md ':include')
 
-1.  In the upper right of any page in the [terraform-ibm-modules](https://github.com/terraform-ibm-modules) organization, use the **+** menu, and select **New repository**.
-1.  Select `terraform-ibm-modules` as the owner.
-1.  Enter a name for the module in format `terraform-ibm-<NAME>`, where `<NAME>` reflects the type of infrastructure that the module manages. Use hyphens as delimiters for names with multiple words (for example, terraform-ibm-`activity-tracker`).
-1.  Provide a short description of the module. The description is displayed under the repository title on the [organization page](https://github.com/terraform-ibm-modules) and in the **About** section of the repository. Use the description to help users understand what your repo does by looking at the description.
-1.  Confirm that you are creating a public repository in the terraform-ibm-modules organization and click **Create repository**.
+When your repo is created, return to this topic and continue the steps.
 
 ## Clone and initialize the repo
 
-Clone the repo that you just created.
+Clone the repo and configure the submodule.
 
-[inc-clone.md](inc-clone.md ':include')
+1.  Clone the repo you want to start working with. Don't fork the repo. The common pipeline automation uses access tokens that are available only on PRs that are opened from branches off the repos.
 
-## Migrate the module code
+    - To clone by using SSH, run the following command. You need a valid SSH key for github.com. For more information, see the steps in the [GitHub docs](https://docs.github.com/en/authentication/connecting-to-github-with-ssh).
+
+        ```bash
+        git clone git@github.com:terraform-ibm-modules/<REPO_NAME>.git
+        ```
+
+    - To clone by using HTTPS, run the following command.
+
+        ```bash
+        git clone https://github.ibm.com/terraform-ibm-modules/<REPO_NAME>.git
+        ```
+
+        Where `<REPO_NAME>` is an existing `terraform-ibm-modules` repo.
+1.  Add the Git submodule.
+
+   ?> **Tip:** You can use the [migration script](https://github.com/terraform-ibm-modules/common-dev-assets/blob/main/repo_migration.sh) in the `common-dev-assets` repo to add the submodule and links.
+
+    ```bash
+    git submodule add https://github.com/terraform-ibm-modules/common-dev-assets
+    ```
+
+1.  Create symbolic links to the submodule by running these commands from the root of the module:
+
+    ```bash
+    ln -s common-dev-assets/module-assets/basic-pre-commit/.pre-commit-config.yaml .pre-commit-config.yaml
+    git add .pre-commit-config.yaml
+    ln -s common-dev-assets/module-assets/ci ci
+    git add ci
+    ln -s common-dev-assets/module-assets/Makefile Makefile
+    git add Makefile
+    ln -s common-dev-assets/module-assets/Brewfile Brewfile
+    git add Brewfile
+    ```
+
+## Migrate your module code
+
+Bring your Terraform logic from your older repo to the new repo.
 
 1.  From the root of the newly cloned repo, create a branch to work in by running the command `git checkout -b ＜YOUR_WORKING_BRANCH>`. Replace `＜YOUR_WORKING_BRANCH>` with your own branch name.
-s
-1.  Push the module code from the older repo to the new one by running these commands:
+
+1.  Push the module code from the older repo to the new one by running these commands. (You can copy the code if you don't want to use Git.)
+
     1.  Add the new repo as a remote to the older repo:
 
         ```bash
@@ -74,7 +109,7 @@ Create or update at least one end-to-end example to test your code changes. You 
 
 ?> **Tip:** You can use the [migration script](https://github.com/terraform-ibm-modules/common-dev-assets/blob/main/repo_migration.sh) in the `common-dev-assets` repo to add the CI code.
 
-1.  Implement (or update) the logic for your module examples by updating the `main.tf`, `version.tf`, `variables.tf`, and `version.tf` Terraform files in the `examples/default` directory.
+1.  Implement (or update) the logic for your module examples by updating the `main.tf`, `version.tf`, `variables.tf`, and `outputs.tf` Terraform files in the `examples/default` directory.
 1.  Update the `README.md` file in the same examples directory to provide some basic information about what the example does.
 
 [inc-examples](inc-examples.md ':include')


### PR DESCRIPTION
### Description

A PDF is attached to make it easier to review contents of the topic: [migrate-module.pdf](https://github.com/terraform-ibm-modules/documentation/files/9337336/migrate-module.pdf)
(Updated at 2022-08-15 @ 9:02 AM EDT)

- Add steps specific to older modules to get them to the new CI processes and module structure.
- Also updates a reference in dev-maintenance

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [x] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
