### PR TITLE
Remove requirement to link to examples

### DIFF
--- a/docs/contribute-module.md
+++ b/docs/contribute-module.md
@@ -117,7 +117,7 @@ After your PR tests pass, create a pull request.
 1.  Run the pre-commit hooks from the root of the repo to identify other changes that you need to make:
 
     ```bash
-    pre-commit run --all-files`
+    pre-commit run --all-files
     ```
 
 1.  Iteratively address all the issues from this check, commit the changes, and run the `pre-commit` command until all tests pass. For example, commit changes to the readme file that is updated from the pre-commit hooks.

--- a/docs/contribute-module.md
+++ b/docs/contribute-module.md
@@ -114,6 +114,13 @@ After your PR tests pass, create a pull request.
     ```bash
     git pull [--rebase] upstream main
     ```
+1.  Run the pre-commit hooks from the root of the repo to identify other changes that you need to make:
+
+    ```bash
+    pre-commit run --all-files`
+    ```
+
+1.  Iteratively address all the issues from this check, commit the changes, and run the `pre-commit` command until all tests pass. For example, commit changes to the readme file that is updated from the pre-commit hooks.
 1.  Push your topic branch to your repo:
 
     ```bash

--- a/docs/inc-examples.md
+++ b/docs/inc-examples.md
@@ -2,7 +2,7 @@ Every module must contain at least one example.
 
 - An example is a [root terraform module](https://www.terraform.io/language/modules#the-root-module) that uses the module and demonstrates its usage.
 - Examples are located in the `examples` directory. See [module structure](module-structure.md).
-- The main readme file includes links to your examples through a pre-commit hook that creates the links when a pull request passes the CI pipeline.
+- The main readme file includes links to your examples that are created by a pre-commit hook that creates the links.
 
 The following recommendations and good practices might help you structure your examples:
 

--- a/docs/inc-examples.md
+++ b/docs/inc-examples.md
@@ -1,8 +1,8 @@
 Every module must contain at least one example.
 
 - An example is a [root terraform module](https://www.terraform.io/language/modules#the-root-module) that uses the module and demonstrates its usage.
-- Examples are located in the `/examples` directory. See [module structure](module-structure.md).
-- After you add an example, link to it from the Examples section in your root-level readme file. See the [readme](https://github.com/terraform-ibm-modules/terraform-ibm-module-template#examples) file from the module template.
+- Examples are located in the `examples` directory. See [module structure](module-structure.md).
+- The main readme file includes links to your examples through a pre-commit hook that creates the links when a pull request passes the CI pipeline.
 
 The following recommendations and good practices might help you structure your examples:
 

--- a/docs/migrate-module.md
+++ b/docs/migrate-module.md
@@ -93,23 +93,13 @@ Copy the following files from the `.github` directory of the terraform-ibm-modul
 1.  Copy the `settings.yml` file.
 1.  Copy the `workflows` directory that contains the GitHub Action workflow
 
-## Make updates to pass the pre-commit checks
-
-1.  Run the pre-commit hooks from the root of the newly cloned repo to identify other changes that you need to make:
-
-    ```bash
-    pre-commit run --all-files
-    ```
-
-1.  Iteratively address all the issues from this check, commit the changes, and run the `pre-commit` command until you have a clean check.
-
 ## Create or update examples
 
 Create or update at least one end-to-end example to test your code changes. You can see the structure in the [examples](https://github.com/terraform-ibm-modules/terraform-ibm-module-template/tree/main/examples) directory of the terraform-ibm-module-template.
 
 ?> **Tip:** You can use the [migration script](https://github.com/terraform-ibm-modules/common-dev-assets/blob/main/repo_migration.sh) in the `common-dev-assets` repo to add the CI code.
 
-1.  Implement (or update) the logic for your module examples by updating the `main.tf`, `outputs.tf`, `provider.tf`, `variables.tf`, and  `version.tf` Terraform files in the `examples/default` directory.
+1.  Implement (or update) the logic for your module examples by updating the `main.tf`, `outputs.tf`, `provider.tf`, `variables.tf`, and `version.tf` Terraform files in the `examples/default` directory.
 1.  Update the `README.md` file in the same examples directory to provide some basic information about what the example does.
 
 [inc-examples](inc-examples.md ':include')
@@ -123,6 +113,16 @@ Validate your Terraform logic by running the examples. Then, update the test scr
     After the examples run, destroy the resources.
 1.  Copy the contents of the [tests](https://github.com/terraform-ibm-modules/terraform-ibm-module-template/tree/main/tests) directory from the terraform-ibm-module-template.
 1.  Update the `pr_test.go` file to run the examples as a unit test. For more information, see [Update the PR tests](contribute-module.md#update-the-pr-tests) in the docs.
+
+## Make updates to pass the pre-commit checks
+
+1.  Run the pre-commit hooks from the root of the newly cloned repo to identify other changes that you need to make:
+
+    ```bash
+    pre-commit run --all-files
+    ```
+
+1.  Iteratively address all the issues from this check, commit the changes, and run the `pre-commit` command until all tests pass. For example, commit changes to the readme file that is updated from the pre-commit hooks.
 
 ## Open an initial pull request
 


### PR DESCRIPTION
### Description

Change guidance about examples. Remove need to manually add links to examples.

Related to https://github.ibm.com/GoldenEye/issues/issues/2307

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [x] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
