### PR TITLE
add markdown source for badges

### DIFF
--- a/docs/badge-status.md
+++ b/docs/badge-status.md
@@ -8,49 +8,59 @@ The readme file for the module in GitHub includes a status badge.
 ### Active statuses
 The following status badges are supported for active modules. The order follows the typical development stages for modules.
 
-<ol>
-  <li>
-    <dl>
-      <dt><img src="https://img.shields.io/badge/Status-Incubating%20(Not%20yet%20consumable)-red?style=plastic" alt="Incubating"></dt>
-      <dd>The module is in early stage and is not yet consumable.</dd>
-    </dl>
-  </li>
-  <li>
-    <dl>
-      <dt><img src="https://img.shields.io/badge/Status-Implemented%20(No%20quality%20checks)-yellowgreen?style=plastic" alt="Stable"></dt>
-      <dd>The module is in advanced development, which indicates that it is valuable to consumers. The module does not yet have quality checks in place.</dd>
-    </dl>
-  </li>
-  <li>
-    <dl>
-      <dt><img src="https://img.shields.io/badge/Status-Stable%20(With%20quality%20checks)-green?style=plastic" alt="Stable (With quality checks)"></dt>
-      <dd>The module is reviewed and approved by the project maintainers. Quality checks are run against the code. The module is supported by the IBM Cloud Terraform modules community.</dd>
-      <dd></dd>
-    </dl>
-  </li>
-  <li>
-    <dl>
-      <dt><img src="https://img.shields.io/badge/Status-Graduated%20(Supported)-brightgreen?style=plastic" alt="Graduated (Supported)"></dt>
-      <dd>The module is reviewed, approved, and supported by IBM.</dd>
-      <dd></dd>
-    </dl>
-  </li>
-</ol>
+1.  ![Incubating (Not yet consumable)](https://img.shields.io/badge/status-Incubating%20(Not%20yet%20consumable)-red)
+
+    - The module is in early stage and is not yet consumable.
+
+    <details>
+      <summary>Markdown (incubating)</summary>
+
+      ```md
+      [![Incubating (Not yet consumable)](https://img.shields.io/badge/status-Incubating%20(Not%20yet%20consumable)-red)](https://terraform-ibm-modules.github.io/documentation/#/badge-status)
+      ```
+    </details>
+1.  ![Implemented (No quality checks)](https://img.shields.io/badge/Status-Implemented%20(No%20quality%20checks)-yellowgreen)
+
+    - The module is in advanced development, which indicates that it is valuable to consumers. The module does not yet have quality checks in place.
+
+    <details>
+      <summary>Markdown (implemented)</summary>
+
+      ```md
+      [![Implemented (No quality checks)](https://img.shields.io/badge/Status-Implemented%20(No%20quality%20checks)-yellowgreen)](https://terraform-ibm-modules.github.io/documentation/#/badge-status)
+      ```
+    </details>
+1.  ![Stable (With quality checks)](https://img.shields.io/badge/Status-Stable%20(With%20quality%20checks)-green)
+
+    - The module is reviewed and approved by the project maintainers. Quality checks are run against the code. The module is supported by the IBM Cloud Terraform modules community.
+
+    <details>
+      <summary>Markdown (stable)</summary>
+
+      ```md
+      [![Stable (With quality checks)](https://img.shields.io/badge/Status-Stable%20(With%20quality%20checks)-green)](https://terraform-ibm-modules.github.io/documentation/#/badge-status)
+      ```
+    </details>
+1.  ![Graduated (Supported)](https://img.shields.io/badge/Status-Graduated%20(Supported)-brightgreen)
+
+    - The module is reviewed, approved, and supported by IBM.
+
+    <details>
+      <summary>Markdown (graduated)</summary>
+
+      ```md
+      [![Graduated (Supported)](https://img.shields.io/badge/Status-Graduated%20(Supported)-brightgreen)](https://terraform-ibm-modules.github.io/documentation/#/badge-status)
+      ```
+    </details>
 
 ### Other statuses
 
-<dl>
-<dt><img src="images/badge-inactive.svg" alt="Inactive"></dt>
-<dd>This module is no longer maintained or is deprecated, and might be archived. Do not use.</dd>
-</dl>
+- ![Inactive](images/badge-inactive.svg "Inactive")
+    - This module is no longer maintained or is deprecated, and might be archived. Do not use.
 
 ## Release badges
 
-<dl>
-  <dt><img src="images/badge-release.svg" alt="latest SemVer release"></dt>
-  <dd>Latest semantic versioning release of the module in GitHub.</dd>
-</dl>
-<dl>
-  <dt><img src="images/badge-release-cloud.svg" alt="Catalog release"></dt>
-  <dd>This module is available in the IBM Cloud catalog.</dd>
-</dl>
+- ![latest SemVer release](images/badge-release.svg "latest SemVer release")
+    - Latest semantic versioning release of the module in GitHub.
+- ![latest SemVer release](images/badge-release-cloud.svg "Catalog release")
+    - This module is available in the IBM Cloud catalog.


### PR DESCRIPTION
### Description

[Viewable internally in docsify](https://pages.github.ibm.com/allen-dean/tim-docs/#/badge-status)

- Add markdown source for pasting into module readme files.
- Also move to markdown syntax from definition list so that we can use `<details>`

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [x] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
