### PR TITLE
specify brew for macOS only

### DIFF
--- a/docs/local-dev-setup.md
+++ b/docs/local-dev-setup.md
@@ -6,10 +6,10 @@ Follow these steps to set up your local development environment for working with
 
 ## Before you begin
 
-- On Microsoft Windows, set up Windows Subsystem for Linux [WSL](https://ubuntu.com/wsl) and run commands within WSL.
 - Make sure that you have a current version of Python 3 and pip.
 - Make sure that a recent stable version of [Go is installed](https://go.dev/doc/install) and available in your PATH environment variable.
-- Make sure that [Homebrew](https://brew.sh) is installed
+- On Microsoft Windows, set up Windows Subsystem for Linux [WSL](https://ubuntu.com/wsl) and run commands within WSL.
+- On macOS, make sure that [Homebrew](https://brew.sh) is installed
 
 ## Clone and initialize the repo
 


### PR DESCRIPTION
### Description

HomeBrew is required only for Mac OS's now.

**Check the relevant boxes:**
- [ ] Bug fix (nonbreaking change that fixes an issue)
- [ ] New feature (nonbreaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Examples or tests (addition or updates of examples or tests)
- [x] Documentation update
- [ ] CI related update (pipeline, etc.)

### Checklist

- [ ] If relevant, a test for the change has been added or updated as part of this PR.
- [ ] If relevant, documentation for the change has been added or updated as part of this PR.

### Merge

- Merge using "Squash and merge".
- Make sure to use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents. The commit message determines whether a new version of the modules needs to be released, and if so, which semver number to use).
