### PR TITLE
Add info about reference architecture

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,4 +4,4 @@ The IBM Cloud Terraform modules project is a collection of open source Terraform
 
 You can use [Terraform](https://www.terraform.io/) to specify your cloud infrastructure resources and services by using the high-level scripting HashiCorp Configuration Language (HCL).
 
-To get started creating modules. see [Authoring guidelines](implementation-guidelines.md) and [Contributing to the IBM Cloud Terraform modules project](/contribute-module.md).
+To get started creating modules. see [Authoring guidelines](implementation-guidelines.md) and [Contributing to the IBM Cloud Terraform modules project](contribute-module.md).

--- a/docs/contribute-docs.md
+++ b/docs/contribute-docs.md
@@ -10,7 +10,7 @@ When changes are merged to the main branch, they are built and published to http
 
 ### Making content changes locally
 
-Fork the repo so you can work locally. You can [preview your changes](/contribute-docs.md#previewing-the-docs-locally) before you create a pull request.
+Fork the repo so you can work locally. You can [preview your changes](contribute-docs.md#previewing-the-docs-locally) before you create a pull request.
 
 1.  Fork the documentation repo.
 1.  Create a working branch from the `main` branch.

--- a/docs/implementation-guidelines.md
+++ b/docs/implementation-guidelines.md
@@ -35,6 +35,15 @@ Include a short description for each input and output variable in the `variables
 
 Include default values where possible and set the sensitive flag as needed. Update the meaning of a type only with agreement of the governance body.
 
+## Reference architecture
+
+If this module is published as a deployable architecture in IBM Cloud, include a reference architecture that describes the design.
+
+- Author the reference architecture in Markdown.
+- Include an architecture diagram.
+- Save the files in the `reference-architectures` directory. See [module structure](module-structure.md).
+- For more information, see the template in the [terraform-ibm-module-template](https://github.com/terraform-ibm-modules/terraform-ibm-module-template/blob/main/reference-architectures/reference-architecture-template.md).
+
 ## Module examples
 
 [inc-examples](inc-examples.md ':include')
@@ -47,7 +56,7 @@ Modules must contain at least one automated validation test that runs Terraform 
 
 Use [Conventional Commit](https://www.conventionalcommits.org) messages when you commit code.
 
-Module changes adhere to [semantic versioning](https://semver.org/), with releases labeled as `{major}.{minor}.{patch}`. [Git tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging) are used to identify the module versions. For more information about versioning see [release compatibility](versioning.md).
+Module changes adhere to [semantic versioning](https://semver.org/), with releases labeled as `{major}.{minor}.{patch}`. [Git tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging) are used to identify the module versions. For more information about versioning, see [release compatibility](versioning.md).
 
 As a module author or contributor, you don't need to release a new version. Conventional commits determine whether a new version of a module is needed and which semantic versioning number to use. When a PR is merged into the main branch, a new release is created by the release automation if the validation pipeline passes. The commit messages are published in the release notes for the module.
 

--- a/docs/module-structure.md
+++ b/docs/module-structure.md
@@ -27,9 +27,12 @@ The following structure describes the [terraform-ibm-module-template](https://gi
 │   │   ├── outputs.tf
 │   ├── nestedB/
 │   ├── .../
+├── reference-architectures/
+│   ├── architecture-example.md
+│   ├── example-architecture-diagram.svg
 ├── tests/
-│   ├── pr_test.go/
-│   ├── other_test.go/
+│   ├── pr_test.go
+│   ├── other_test.go
 │   ├── .../
 ├── .gitmodules
 ├── .pre-commit-config.yaml


### PR DESCRIPTION
### Description

Adds information about reference architectures.

GitHub issue: https://github.com/terraform-ibm-modules/terraform-ibm-issue-tracker/issues/54

### Types of changes in this PR

#### No release required

- [ ] Examples or tests (addition or updates of examples or tests)
- [x] Documentation update
- [ ] CI-related update (pipeline, etc.)
- [ ] Other changes that don't affect Terraform code

#### Release required

- [ ] Bug fix (patch release (`x.x.X`): Change that fixes an issue and is compatible with earlier versions)
- [ ] New feature (minor release (`x.X.x`): Change that adds functionality and is compatible with earlier versions)
- [ ] Breaking change (major release (`X.x.x`): Change that is likely incompatible with previous versions)

##### Release notes content

Replace this text with information that users need to know about the bug fixes, features, and breaking changes. This information helps the merger write the commit message that is published in the release notes for the module.

---

### Checklist for reviewers

- [ ] The PR references a GitHub issue.
- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- Merge by using "Squash and merge".
- Use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author.

    The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
