### PR TITLE
remove conventional commit

### DIFF
--- a/docs/contribute-module.md
+++ b/docs/contribute-module.md
@@ -111,7 +111,7 @@ For more information about testing modules in this project, see [Tests](tests.md
 
 After your PR tests pass, create a pull request.
 
-!> **Important**: Use [Conventional Commit](https://www.conventionalcommits.org) messages when you commit code ([cheat sheet](https://cheatography.com/albelop/cheat-sheets/conventional-commits/)). Conventional commits determine whether a new version of a module is needed and which [semantic versioning number](versioning.md) to use. The commit messages are published in the release notes for the module.
+When the PR is merged, your commit messages might change because the merging team uses the [squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits) option to merge PRs. The PR commit message determines whether a new version of a module is needed and which [semantic versioning number](versioning.md) to use. The message also is published in the release notes for the module.
 
 1.  Locally merge (or rebase) the upstream `main` branch into your topic branch:
 

--- a/docs/contribute-module.md
+++ b/docs/contribute-module.md
@@ -111,7 +111,7 @@ For more information about testing modules in this project, see [Tests](tests.md
 
 After your PR tests pass, create a pull request.
 
-When the PR is merged, your commit messages might change because the merging team uses the [squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits) option to merge PRs. The PR commit message determines whether a new version of a module is needed and which [semantic versioning number](versioning.md) to use. The message also is published in the release notes for the module.
+When the PR is merged, your commit messages might change because the merging team uses the [squash and merge](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/incorporating-changes-from-a-pull-request/about-pull-request-merges#squash-and-merge-your-pull-request-commits) option to merge PRs. The PR commit message that's included by the merging team determines whether a new version of a module is needed and which [semantic versioning number](versioning.md) to use. The message also is published in the release notes for the module.
 
 1.  Locally merge (or rebase) the upstream `main` branch into your topic branch:
 

--- a/docs/contribute-module.md
+++ b/docs/contribute-module.md
@@ -13,8 +13,9 @@ Follow these steps to create or update a module.
 ## Before you begin
 
 - If you're running Microsoft Windows, set up Windows Subsystem for Linux [WSL](https://ubuntu.com/wsl) and run commands within WSL.
-- Make sure that you have a current version of Python 3 and pip. 
-  - To check your installed version, run `python --version`.
+- Make sure that you have a current version of Python 3 and pip.
+  - To check your installed python version, run `python3 --version`.
+  - To check whether "pip" is installed, run `python3 -m pip --version`.
 - Make sure that you have a recent stable version of [Go](https://go.dev/doc/install) installed and available in your PATH environment variable.
 
 ## Request a repo

--- a/docs/gh-actions.md
+++ b/docs/gh-actions.md
@@ -7,7 +7,7 @@ The following reusable workflows are included in the [terraform-ibm-module-templ
 - `common-terraform-module-ci` for pull requests and merges into main branch.
 
     - Called from `/.github/workflows/ci.yml`.
-    - If you have GitHub collaborators access, you can run this workflow by adding a comment to the pull request with the following text:
+    - If you are in the `github-collaborators` team, you can run this workflow by adding a comment to the pull request with the following text:
 
         ```
         /run pipeline

--- a/docs/implementation-guidelines.md
+++ b/docs/implementation-guidelines.md
@@ -53,14 +53,10 @@ If this module is published as a deployable architecture in IBM Cloud, include a
 
 Modules must contain at least one automated validation test that runs Terraform apply and destroy commands, and tests the idempotency of the module. See [Validation tests](tests.md) for details.
 
-## Commit messages and versioning
+## Versioning
 
 Module changes adhere to [semantic versioning](https://semver.org/), with releases labeled as `{major}.{minor}.{patch}`. [Git tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging) are used to identify the module versions. For more information about versioning, see [Release versioning](versioning.md).
 
-As a module author or contributor, you don't need to release a new version. The merging team determines whether a new version of a module is needed and which semantic versioning number to use based on the commits in the PR. When a PR is merged into the main branch, a new release is created by the release automation if the validation pipeline passes. The commit messages are published in the release notes for the module.
-
-
-For more information about Conventional Commits, see this handy [cheat sheet](https://cheatography.com/albelop/cheat-sheets/conventional-commits/).
 ## Module documentation
 
 Document the module in the readme file at the same level as the `main.tf` file for each of the modules in a repository, including the example modules. Put content that isn't required initially in a `docs` subdirectory. For more information about the title and description, see [Module names and descriptions](#module-names-and-descriptions).

--- a/docs/implementation-guidelines.md
+++ b/docs/implementation-guidelines.md
@@ -55,11 +55,10 @@ Modules must contain at least one automated validation test that runs Terraform 
 
 ## Commit messages and versioning
 
-Use [Conventional Commit](https://www.conventionalcommits.org) messages when you commit code.
-
 Module changes adhere to [semantic versioning](https://semver.org/), with releases labeled as `{major}.{minor}.{patch}`. [Git tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging) are used to identify the module versions. For more information about versioning, see [Release versioning](versioning.md).
 
-As a module author or contributor, you don't need to release a new version. Conventional commits determine whether a new version of a module is needed and which semantic versioning number to use. When a PR is merged into the main branch, a new release is created by the release automation if the validation pipeline passes. The commit messages are published in the release notes for the module.
+As a module author or contributor, you don't need to release a new version. The merging team determines whether a new version of a module is needed and which semantic versioning number to use based on the commits in the PR. When a PR is merged into the main branch, a new release is created by the release automation if the validation pipeline passes. The commit messages are published in the release notes for the module.
+
 
 For more information about Conventional Commits, see this handy [cheat sheet](https://cheatography.com/albelop/cheat-sheets/conventional-commits/).
 ## Module documentation

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -27,7 +27,6 @@ Make sure that you include at least these two tests:
 
     Use the `RunTestUpgrade()` test helper to help determine compatibility with earlier module versions.
 
-    - If you must implement a breaking change to the module in a PR, include a Conventional Commit footer in one of the commits with the text `BREAKING CHANGE:` at the beginning of the footer. For more information, see the [Conventional Commits cheat sheet](https://cheatography.com/albelop/cheat-sheets/conventional-commits/).
     - If the change breaks example code but not module code, include `SKIP UPGRADE TEST` in the commit message. Make sure to describe why you are breaking the example in the PR description.
 
   ?> **Tip**: The upgrade test is disabled by default in `pr_test.go` in the module template because you can't run an upgrade test until the initial module code is merged to the main branch. After the initial merge, create a pull request to enable the upgrade test by commenting out the line that starts with `t.Skip`.

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -27,9 +27,7 @@ Make sure that you include at least these two tests:
 
     Use the `RunTestUpgrade()` test helper to help determine compatibility with earlier module versions.
 
-    - If the change breaks example code but not module code, include `SKIP UPGRADE TEST` in the commit message. Make sure to describe why you are breaking the example in the PR description.
-
-  ?> **Tip**: The upgrade test is disabled by default in `pr_test.go` in the module template because you can't run an upgrade test until the initial module code is merged to the main branch. After the initial merge, create a pull request to enable the upgrade test by commenting out the line that starts with `t.Skip`.
+  ?> **Tip**: If you're working on the first PR for a module, skip the upgrade in `pr_test.go` because you can't run an upgrade test until the initial module code is merged to the main branch. To skip the test, include `SKIP UPGRADE TEST` in the commit message. Include information about why you're skipping the test.
 
 - **IBM Cloud Schematics test**
 


### PR DESCRIPTION

### Description

Conventional commits are no longer a requirement.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- When merging, use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
