### PR TITLE
fix link to ref arch template

### DIFF
--- a/docs/implementation-guidelines.md
+++ b/docs/implementation-guidelines.md
@@ -40,7 +40,7 @@ Include default values where possible and set the sensitive flag as needed. Upda
 If this module is published as a deployable architecture in IBM Cloud, include a reference architecture that describes the design.
 
 - Author the reference architecture in Markdown.
-- Start from the [Markdown template](https://github.ibm.com/allen-dean/tim-docs/raw/main/docs/templates/reference-architecture-template.md ':target=_blank') to guide you.
+- Start from the [Markdown template](https://github.com/terraform-ibm-modules/documentation/raw/main/docs/templates/reference-architecture-template.md ':target=_blank') to guide you.
 - Include an architecture diagram.
 - Save the files in your module in the `reference-architectures` directory.
 - For more information, see the template in the [documentation](https://github.com/terraform-ibm-modules/documentation/blob/main/docs/templates/reference-architecture-template.md) repo.


### PR DESCRIPTION
### Description

Link to reference architecture template was pointing to internal repo.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
